### PR TITLE
Fix broken link

### DIFF
--- a/youtube-all-vids-info.html
+++ b/youtube-all-vids-info.html
@@ -32,7 +32,7 @@ Your Youtube API Access Key: <input id="accesskey" type="text" size="50"> | <sma
 Uploads Playlist Id: <input id="playlistId" type="text" size="40" value="UUT7EcU7rC44DiS3RkfZzZMg"> | <small><a target="_blank" href="https://developers.google.com/apis-explorer/#p/youtube/v3/youtube.channels.list?part=contentDetails&forUsername=arvindguptatoys&fields=items%252FcontentDetails%252CpageInfo%252FtotalResults" title="yes, even all the videos on a channel are in a playlist called 'uploads'">Click here to find playlist Id (requires username or channel id)</a></small><br>
 
 Number of videos to fetch: <input id="vidslimit" type="text" value="200" size="10"> | <small>will start from latest</small> | 
-<small><a target="_blank" href="javascript:findTotalVids()">Click here to calculate the total number of videos (requires the playlist id)</a></small>
+<small><a href="javascript:findTotalVids()">Click here to calculate the total number of videos (requires the playlist id)</a></small>
 
 <p><small>Page Token to start from, if any: <input id="startToken" type="text" value="" size="10"> | In case you want to pick up where you left off and not have to cycle through the ones already covered</small></p>
 


### PR DESCRIPTION
Remove `target="_blank"` from link that calculates total number of videos in the playlist. This calculation is done on the page. There is no need to open a new browser tab.